### PR TITLE
Changes required for Python 3.x compatibility

### DIFF
--- a/circ2/fetch_ucsc.py
+++ b/circ2/fetch_ucsc.py
@@ -36,13 +36,13 @@ def fetch_file(options):
         kg_iso = {}
         with gzip.open('kgXref.txt.gz', 'rb') as kg_id_f:
             for line in kg_id_f:
-                iso = line.split('\t')[0]
-                gene = line.split('\t')[4].translate(s)
+                iso = line.decode().split('\t')[0]
+                gene = line.decode().split('\t')[4].translate(s)
                 kg_iso[iso] = gene
         with gzip.open('knownGene.txt.gz', 'rb') as kg_f:
             with open(options[3], 'w') as outf:
                 for line in kg_f:
-                    entry = line.split('\t')
+                    entry = line.decode().split('\t')
                     iso = entry[0]
                     outf.write('\t'.join([kg_iso[iso]] + entry[:10]) + '\n')
     elif options[2] == 'ens':  # Ensembl gene annotations
@@ -54,12 +54,12 @@ def fetch_file(options):
         ens_iso = {}
         with gzip.open('ensemblToGeneName.txt.gz', 'rb') as ens_id_f:
             for line in ens_id_f:
-                iso, gene = line.split()
+                iso, gene = line.decode().split()
                 ens_iso[iso] = gene
         with gzip.open('ensGene.txt.gz', 'rb') as ens_f:
             with open(options[3], 'w') as outf:
                 for line in ens_f:
-                    entry = line.split()
+                    entry = line.decode().split()
                     iso = entry[1]
                     outf.write('\t'.join([ens_iso[iso]] + entry[1:11]) + '\n')
     elif options[2] == 'fa':  # Genome sequences
@@ -72,7 +72,8 @@ def fetch_file(options):
             with open(options[3], 'w') as outf:
                 for f in fa:
                     if f.isfile():
-                        outf.write(fa.extractfile(f).read())
+                        content = fa.extractfile(f).read()
+                        outf.write(content.decode())
         pysam.faidx(options[3])
     else:
         sys.exit('Only support ref/kg/ens/fa!')


### PR DESCRIPTION
Using this script to create the 'hg19_kg.txt', 'hg19_ens.txt', and 'hg19.fa' files with Python 3.x resulted in a type error (e.g. "TypeError: a bytes-like object is required, not 'str'").